### PR TITLE
Fix message design in message screen

### DIFF
--- a/lib/page/message.dart
+++ b/lib/page/message.dart
@@ -17,6 +17,12 @@ class Message {
 class MessageScreenState extends State<MessageScreen> {
   final List<Message> _messages = [];
   final TextEditingController _controller = TextEditingController();
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+  }
 
   void _sendMessage() {
     if (_controller.text.isNotEmpty) {
@@ -24,6 +30,11 @@ class MessageScreenState extends State<MessageScreen> {
         _messages.add(Message(_controller.text));
         _controller.clear();
       });
+      _scrollController.animateTo(
+        _scrollController.position.maxScrollExtent,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeOut,
+      );
     }
   }
 
@@ -37,6 +48,7 @@ class MessageScreenState extends State<MessageScreen> {
         children: <Widget>[
           Expanded(
             child: ListView.builder(
+              controller: _scrollController,
               itemCount: _messages.length,
               itemBuilder: (context, index) {
                 return Row(

--- a/lib/page/message.dart
+++ b/lib/page/message.dart
@@ -39,28 +39,32 @@ class MessageScreenState extends State<MessageScreen> {
             child: ListView.builder(
               itemCount: _messages.length,
               itemBuilder: (context, index) {
-                return Container(
-                  margin: const EdgeInsets.symmetric(vertical: 5, horizontal: 10),
-                  padding: const EdgeInsets.all(10),
-                  decoration: BoxDecoration(
-                    color: Colors.blue[100],
-                    borderRadius: BorderRadius.circular(10),
-                  ),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
-                      Text(
-                        _messages[index].timestamp.toLocal().toString().split(' ')[1].substring(0, 5),
-                        style: const TextStyle(fontSize: 12, color: Colors.grey),
-                      ),
-                      Expanded(
-                        child: Text(
-                          _messages[index].text,
-                          textAlign: TextAlign.right,
+                return Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      children: [
+                        Container(
+                          margin: const EdgeInsets.symmetric(vertical: 5, horizontal: 10),
+                          padding: const EdgeInsets.all(10),
+                          decoration: BoxDecoration(
+                            color: Colors.blue[100],
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                          child: Text(
+                            _messages[index].text,
+                            textAlign: TextAlign.right,
+                            style: const TextStyle(color: Colors.white),
+                          ),
                         ),
-                      ),
-                    ],
-                  ),
+                        Text(
+                          _messages[index].timestamp.toLocal().toString().split(' ')[1].substring(0, 5),
+                          style: const TextStyle(fontSize: 12, color: Colors.grey),
+                        ),
+                      ],
+                    ),
+                  ],
                 );
               },
             ),

--- a/lib/page/message.dart
+++ b/lib/page/message.dart
@@ -7,14 +7,21 @@ class MessageScreen extends StatefulWidget {
   MessageScreenState createState() => MessageScreenState();
 }
 
+class Message {
+  final String text;
+  final DateTime timestamp;
+
+  Message(this.text) : timestamp = DateTime.now();
+}
+
 class MessageScreenState extends State<MessageScreen> {
-  final List<String> _messages = [];
+  final List<Message> _messages = [];
   final TextEditingController _controller = TextEditingController();
 
   void _sendMessage() {
     if (_controller.text.isNotEmpty) {
       setState(() {
-        _messages.add(_controller.text);
+        _messages.add(Message(_controller.text));
         _controller.clear();
       });
     }
@@ -32,8 +39,28 @@ class MessageScreenState extends State<MessageScreen> {
             child: ListView.builder(
               itemCount: _messages.length,
               itemBuilder: (context, index) {
-                return ListTile(
-                  title: Text(_messages[index]),
+                return Container(
+                  margin: const EdgeInsets.symmetric(vertical: 5, horizontal: 10),
+                  padding: const EdgeInsets.all(10),
+                  decoration: BoxDecoration(
+                    color: Colors.blue[100],
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: <Widget>[
+                      Text(
+                        _messages[index].timestamp.toLocal().toString().split(' ')[1].substring(0, 5),
+                        style: const TextStyle(fontSize: 12, color: Colors.grey),
+                      ),
+                      Expanded(
+                        child: Text(
+                          _messages[index].text,
+                          textAlign: TextAlign.right,
+                        ),
+                      ),
+                    ],
+                  ),
                 );
               },
             ),

--- a/lib/page/message.dart
+++ b/lib/page/message.dart
@@ -32,7 +32,7 @@ class MessageScreenState extends State<MessageScreen> {
       });
       _scrollController.animateTo(
         _scrollController.position.maxScrollExtent,
-        duration: const Duration(milliseconds: 300),
+        duration: const Duration(milliseconds: 100),
         curve: Curves.easeOut,
       );
     }

--- a/lib/page/message.dart
+++ b/lib/page/message.dart
@@ -42,11 +42,22 @@ class MessageScreenState extends State<MessageScreen> {
                 return Row(
                   mainAxisAlignment: MainAxisAlignment.end,
                   children: [
-                    Column(
+                    Row(
                       crossAxisAlignment: CrossAxisAlignment.end,
                       children: [
+                        Text(
+                          _messages[index]
+                              .timestamp
+                              .toLocal()
+                              .toString()
+                              .split(' ')[1]
+                              .substring(0, 5),
+                          style:
+                              const TextStyle(fontSize: 12, color: Colors.grey),
+                        ),
                         Container(
-                          margin: const EdgeInsets.symmetric(vertical: 5, horizontal: 10),
+                          margin: const EdgeInsets.symmetric(
+                              vertical: 5, horizontal: 10),
                           padding: const EdgeInsets.all(10),
                           decoration: BoxDecoration(
                             color: Colors.blue[100],
@@ -57,10 +68,6 @@ class MessageScreenState extends State<MessageScreen> {
                             textAlign: TextAlign.right,
                             style: const TextStyle(color: Colors.white),
                           ),
-                        ),
-                        Text(
-                          _messages[index].timestamp.toLocal().toString().split(' ')[1].substring(0, 5),
-                          style: const TextStyle(fontSize: 12, color: Colors.grey),
                         ),
                       ],
                     ),
@@ -76,9 +83,7 @@ class MessageScreenState extends State<MessageScreen> {
                 Expanded(
                   child: TextField(
                     controller: _controller,
-                    decoration: const InputDecoration(
-                      hintText: 'Enter message',
-                    ),
+                    decoration: const InputDecoration(),
                   ),
                 ),
                 FloatingActionButton(


### PR DESCRIPTION
Update the message sending screen design.

* Add a `Message` class with `text` and `timestamp` fields.
* Replace the `ListTile` widget with a `Container` widget that includes a `Row` with the timestamp and message text.
* Align the user's message to the right and set a background color for the message.
* Update the `_sendMessage` function to add the sending time to the `_messages` list.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sakagami-t/talk_app/pull/2?shareId=d6747d29-828b-4434-9200-cebee168f650).